### PR TITLE
strip any excess spaces that might be trailing Abstract

### DIFF
--- a/doc2tex/sce_utils/utils.py
+++ b/doc2tex/sce_utils/utils.py
@@ -136,7 +136,7 @@ def document_structure(ftex_in):
             if line.split("{")[1].strip()[0].isdigit():  # try to remove numbering
                 sname = " ".join(line.split("{")[1].split("}")[0].split(" ")[1:])
             else:
-                sname = line.split("{")[1].split("}")[0]
+                sname = line.split("{")[1].split("}")[0].strip()
             sect = {"sname": sname, "level": line.split("{")[0][1:], "line": i}
             struct[j] = sect
             j += 1


### PR DESCRIPTION
To match "Abstract" section heading the string the code finds has to cope if the authors left a trailing space ("Abstract "). Strip this space in the keys for the structure dict so that there will be a matching key when we go to start parsing the file.